### PR TITLE
Add README with usage and attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Last Shot Hoops: Skill Edition
+
+A simple basketball timing game built with HTML, CSS and JavaScript. Stop the slider in the green zone to make the perfect play.
+
+## Opening the Game
+
+Just open `index.html` in any modern web browser. If you are working from a command-line or remote environment, you can run a simple local server (for example `python3 -m http.server`) and then navigate to `http://localhost:8000`.
+
+## Gameplay
+
+1. Choose an action: **Drive Left**, **Pull Up**, or **Pass to Wing**.
+2. A slider will move back and forth. Click **Tap!** to stop the indicator.
+3. Landing in the green zone is **PERFECT**, yellow is **Good**, and anywhere else is a miss.
+4. The message at the top tells you the outcome of your move.
+
+## Asset Attribution
+
+- Background court image from [Wikimedia Commons](https://upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Basketball_Court.png/1024px-Basketball_Court.png).
+- Player sprite from [Kenney.nl Platformer Art Deluxe](https://kenney.nl/assets/platformer-art-deluxe).
+
+## Purpose
+
+This project demonstrates a minimal interactive basketball game that can be run in any web browser. It is intended for experimentation with simple timing mechanics.
+


### PR DESCRIPTION
## Summary
- document gameplay, asset sources and project purpose in README
- explain how to open `index.html` in a browser

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846c8c09b748332bf77ed07564b4b26