### PR TITLE
Add basic jest testing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Hoop Game
+
+This repository contains a simple basketball timing game implemented in HTML and JavaScript. A small testing setup using [Jest](https://jestjs.io/) is provided to verify the slider timing logic.
+
+## Running the game
+Open `index.html` in a web browser to play.
+
+## Running tests
+1. Install dependencies (Jest) with `npm install`.
+2. Run the test suite with:
+   ```bash
+   npm test
+   ```
+
+The tests verify that specific `sliderPos` values yield the correct outcome strings (`"PERFECT!"`, `"Good!"`, or `"Miss!"`).

--- a/__tests__/gameLogic.test.js
+++ b/__tests__/gameLogic.test.js
@@ -1,0 +1,17 @@
+const { getOutcome } = require('../gameLogic');
+
+describe('getOutcome', () => {
+  test('returns PERFECT! for green zone', () => {
+    expect(getOutcome(145)).toBe('PERFECT!');
+  });
+
+  test('returns Good! for yellow zones', () => {
+    expect(getOutcome(120)).toBe('Good!');
+    expect(getOutcome(170)).toBe('Good!');
+  });
+
+  test('returns Miss! outside zones', () => {
+    expect(getOutcome(95)).toBe('Miss!');
+    expect(getOutcome(200)).toBe('Miss!');
+  });
+});

--- a/gameLogic.js
+++ b/gameLogic.js
@@ -1,0 +1,12 @@
+function getOutcome(sliderPos) {
+  if (sliderPos >= 140 && sliderPos <= 150) {
+    return "PERFECT!";
+  } else if ((sliderPos >= 110 && sliderPos < 140) || (sliderPos > 150 && sliderPos <= 190)) {
+    return "Good!";
+  }
+  return "Miss!";
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { getOutcome };
+}

--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@
     </div>
   </div>
 
+  <script src="gameLogic.js"></script>
   <script>
     const message = document.getElementById('message');
     const actions = document.getElementById('actions');
@@ -138,12 +139,7 @@
       clearInterval(sliderInterval);
       sliderContainer.style.display = "none";
 
-      let outcome = "Miss!";
-      if (sliderPos >= 140 && sliderPos <= 150) {
-        outcome = "PERFECT!";
-      } else if ((sliderPos >= 110 && sliderPos < 140) || (sliderPos > 150 && sliderPos <= 190)) {
-        outcome = "Good!";
-      }
+      const outcome = getOutcome(sliderPos);
 
       if (actionType === "shoot") {
         message.innerText = outcome === "PERFECT!" ? "It's GOOD! YOU WIN!" :

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "hoop-game",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.6.1"
+  }
+}


### PR DESCRIPTION
## Summary
- extract slider outcome logic into `gameLogic.js`
- import that logic in `index.html`
- configure Jest and provide example tests
- document how to run the tests

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c8c1fdbc8332966f44d75d8c5516